### PR TITLE
Make use 'RandomSampler' by default

### DIFF
--- a/torchreid/data/datamanager.py
+++ b/torchreid/data/datamanager.py
@@ -98,7 +98,7 @@ class ImageDataManager(DataManager):
         workers (int, optional): number of workers. Default is 4.
         num_instances (int, optional): number of instances per identity in a batch.
             Default is 4.
-        train_sampler (str, optional): sampler. Default is empty (``RandomSampler``).
+        train_sampler (str, optional): sampler. Default is ``RandomSampler``.
         cuhk03_labeled (bool, optional): use cuhk03 labeled images.
             Default is False (defaul is to use detected images).
         cuhk03_classic_split (bool, optional): use the classic split in cuhk03.
@@ -121,7 +121,7 @@ class ImageDataManager(DataManager):
 
     def __init__(self, root='', sources=None, targets=None, height=256, width=128, transforms='random_flip',
                  norm_mean=None, norm_std=None, use_gpu=True, split_id=0, combineall=False,
-                 batch_size_train=32, batch_size_test=32, workers=4, num_instances=4, train_sampler='',
+                 batch_size_train=32, batch_size_test=32, workers=4, num_instances=4, train_sampler='RandomSampler',
                  cuhk03_labeled=False, cuhk03_classic_split=False, market1501_500k=False):
         
         super(ImageDataManager, self).__init__(sources=sources, targets=targets, height=height, width=width,

--- a/torchreid/data/sampler.py
+++ b/torchreid/data/sampler.py
@@ -76,7 +76,7 @@ class RandomIdentitySampler(Sampler):
         return self.length
 
 
-def build_train_sampler(data_source, train_sampler, batch_size=32, num_instances=4, **kwargs):
+def build_train_sampler(data_source, train_sampler='RandomSampler', batch_size=32, num_instances=4, **kwargs):
     """Builds a training sampler.
 
     Args:


### PR DESCRIPTION
as its described in docstring

Fixes: Instantiating ImageDataManager as it's described in 'Get started'
from repository's readme causes an error from 'build_train_sampler'
because `` is not in AVAI_SAMPLERS