### PR TITLE
save relabelling mapping to csv

### DIFF
--- a/torchreid/data/datasets/dataset.py
+++ b/torchreid/data/datasets/dataset.py
@@ -293,6 +293,24 @@ class ImageDataset(Dataset):
         )
         print('  ----------------------------------------')
 
+    def save_relabel_file(self, data_dir, relabel_map):
+        """
+        Save the mapping <pid_old, pid_new> after relabelling to csv.
+        :param data_dir: path to dataset that contains training set
+        :param relabel_map: a dict in the form of {pid_old:pid_new}
+        :return: None
+        """
+        import csv
+        from datetime import datetime
+        now = datetime.now()
+        relabel_record_path = osp.join(data_dir, "train_relabel"+now.strftime("_%H-%M-%S")+".csv")
+        with open(relabel_record_path, 'w+') as f:
+            csv_writer = csv.writer(f)
+            csv_writer.writerow(['train_set_pid', 'new_label'])
+            for pid_old in relabel_map.keys():
+                csv_writer.writerow([pid_old, relabel_map[pid_old]])
+        print("Record of relabel mapping saved to ", relabel_record_path)
+
 
 class VideoDataset(Dataset):
     """A base class representing VideoDataset.

--- a/torchreid/data/datasets/image/dukemtmcreid.py
+++ b/torchreid/data/datasets/image/dukemtmcreid.py
@@ -64,4 +64,7 @@ class DukeMTMCreID(ImageDataset):
             if relabel: pid = pid2label[pid]
             data.append((img_path, pid, camid))
 
+        if relabel:
+            self.save_relabel_file(self.dataset_dir, relabel_map=pid2label)
+
         return data

--- a/torchreid/data/datasets/image/market1501.py
+++ b/torchreid/data/datasets/image/market1501.py
@@ -85,4 +85,7 @@ class Market1501(ImageDataset):
                 pid = pid2label[pid]
             data.append((img_path, pid, camid))
 
+        if relabel:
+            self.save_relabel_file(self.data_dir, relabel_map=pid2label)
+
         return data


### PR DESCRIPTION
Ref: #284 

- Summary: save `<old dataset pid, new pid>` to csv. This can be useful when users want to perform evaluation on training set using pre-trained model. In [current implementation](https://github.com/KaiyangZhou/deep-person-reid/blob/a9bcf6af2461d4bc58df5ad0359bb0dd17b5797d/torchreid/data/datasets/image/market1501.py#L56), train set will be relabelled for the continuity of label index. However, problems may arise because this mapping relationship is not visible to user, and is subject to different file indexing mechanism [(stackoverflow)](https://stackoverflow.com/questions/6773584/how-is-pythons-glob-glob-ordered). Therefore, training set may have different labels depending on machines, making it hard to reproduce the result. 
- Old behaviour: does not save remapping file.
- New behaviour: saves relabel mapping as csv to dataset directory. Eg: `market1501/train_relabel_18-13-31.csv`