### PR TITLE
Update mudeep.py to support testing

### DIFF
--- a/torchreid/models/mudeep.py
+++ b/torchreid/models/mudeep.py
@@ -194,7 +194,10 @@ class MuDeep(nn.Module):
         x = x.view(x.size(0), -1)
         x = self.fc(x)
         y = self.classifier(x)
-
+        
+        if not self.training:
+            return x
+        
         if self.loss == 'softmax':
             return y
         elif self.loss == 'triplet':


### PR DESCRIPTION
Fix for https://github.com/KaiyangZhou/deep-person-reid/issues/431
Current model fails in the case of triplet loss during testing since y,x returns a tuple whereas engine.py features expects a torch tensor instead to run features.cpu()