### PR TITLE
FeatureExtractor: avoid loading weights twice

### DIFF
--- a/torchreid/utils/feature_extractor.py
+++ b/torchreid/utils/feature_extractor.py
@@ -71,7 +71,7 @@ class FeatureExtractor(object):
         model = build_model(
             model_name,
             num_classes=1,
-            pretrained=True,
+            pretrained=not (model_path and check_isfile(model_path)),
             use_gpu=device.startswith('cuda')
         )
         model.eval()


### PR DESCRIPTION
When passing a model_path to the FeatureExtractor, weights are loaded twice.
One the pretrained once and then the given ones. Avoid the unnecessary load.