### PR TITLE
Add optional arguments to ImageDataManager

### DIFF
--- a/torchreid/data/datamanager.py
+++ b/torchreid/data/datamanager.py
@@ -175,7 +175,8 @@ class ImageDataManager(DataManager):
         train_sampler_t='RandomSampler',
         cuhk03_labeled=False,
         cuhk03_classic_split=False,
-        market1501_500k=False
+        market1501_500k=False,
+        **kwargs
     ):
 
         super(ImageDataManager, self).__init__(
@@ -202,7 +203,8 @@ class ImageDataManager(DataManager):
                 split_id=split_id,
                 cuhk03_labeled=cuhk03_labeled,
                 cuhk03_classic_split=cuhk03_classic_split,
-                market1501_500k=market1501_500k
+                market1501_500k=market1501_500k,
+                **kwargs
             )
             trainset.append(trainset_)
         trainset = sum(trainset)

--- a/torchreid/data/datamanager.py
+++ b/torchreid/data/datamanager.py
@@ -204,7 +204,7 @@ class ImageDataManager(DataManager):
                 cuhk03_labeled=cuhk03_labeled,
                 cuhk03_classic_split=cuhk03_classic_split,
                 market1501_500k=market1501_500k,
-                **kwargs
+                **kwargs 
             )
             trainset.append(trainset_)
         trainset = sum(trainset)


### PR DESCRIPTION
Add **kwargs optional arguments to ImageDataManager

I defined a custom ImageDataset, which takes some additional arguments for init.

According to [use custom dataset](https://kaiyangzhou.github.io/deep-person-reid/user_guide.html#use-your-own-dataset), the officially recommended way to use the dataset is to use the ImageDataManager

I tried to pass **kwargs(a dict) into the torchreid.data.ImageDataManager() constructor. Unfortunately, due to the **positional(fixed)** arguments of the function `init_image_dataset` (in datamanager.py), the constructor of my own custom dataset cannot receive any additional arguaments.

I hope it will fix the problem!